### PR TITLE
Draft of abort_timeout and redis namespace

### DIFF
--- a/src/dramatiq_abort/__init__.py
+++ b/src/dramatiq_abort/__init__.py
@@ -1,7 +1,7 @@
 __version__ = "0.4.0"
 
 from .abort_manager import Abort
-from .backend import EventBackend
+from .backend import Event, EventBackend
 from .middleware import Abortable, abort, abort_requested
 
-__all__ = ["EventBackend", "Abortable", "Abort", "abort", "abort_requested"]
+__all__ = ["Event", "EventBackend", "Abortable", "Abort", "abort", "abort_requested"]

--- a/src/dramatiq_abort/__init__.py
+++ b/src/dramatiq_abort/__init__.py
@@ -1,6 +1,7 @@
 __version__ = "0.4.0"
 
+from .abort_manager import Abort
 from .backend import EventBackend
-from .middleware import Abort, Abortable, abort
+from .middleware import Abortable, abort, abort_requested
 
-__all__ = ["EventBackend", "Abortable", "Abort", "abort"]
+__all__ = ["EventBackend", "Abortable", "Abort", "abort", "abort_requested"]

--- a/src/dramatiq_abort/abort_manager.py
+++ b/src/dramatiq_abort/abort_manager.py
@@ -69,7 +69,7 @@ class AbortManager(abc.ABC):
         return list(self.abortable_messages.keys())
 
     def get_abort_request(self, message_id: Optional[str] = None) -> Optional[float]:
-        if message_id:
+        if message_id:  # pragma: no cover
             thread = self.abortable_messages.get(message_id, None)
         else:
             thread = self.get_current_thread()
@@ -79,7 +79,7 @@ class AbortManager(abc.ABC):
     def add_abort_request(self, message_id: str, abort_timeout: int = 0) -> None:
         with self.lock:
             thread = self.abortable_messages.get(message_id, None)
-            if thread is None:
+            if thread is None:  # pragma: no cover
                 # If the task finished before we signaled it to abort
                 return
             self.abort_requests[thread] = (

--- a/src/dramatiq_abort/abort_manager.py
+++ b/src/dramatiq_abort/abort_manager.py
@@ -1,0 +1,142 @@
+import abc
+import contextlib
+import threading
+import time
+from logging import Logger
+from threading import Thread
+from typing import Any, ContextManager, Dict, List, Optional, Tuple
+
+from dramatiq.logging import get_logger
+from dramatiq.middleware.threading import Interrupt, raise_thread_exception
+
+
+def is_gevent_active() -> bool:
+    """Detect if gevent monkey patching is active.
+
+    This function should be removed and replaced with the identically named
+    function imported from dramatiq.middleware.threading as soon as a
+    dependency on a version of dramatiq with this function can be made.
+    """
+    try:
+        from gevent import monkey
+    except ImportError:  # pragma: no cover
+        return False
+    return bool(monkey.saved)
+
+
+class Abort(Interrupt):
+    """Exception used to interrupt worker threads when their worker
+    processes have been signaled to abort.
+    """
+
+
+class AbortManager(abc.ABC):
+    """ABC for raising Abort exceptions in threads.
+
+    :param logger: The logger for abort log lines.
+    :type logger: :class:`logging.Logger`
+    """
+
+    logger: Any
+    lock: ContextManager[Any]
+    abortable_messages: Dict[str, Any]
+    abort_requests: Dict[Any, Tuple[str, float]]
+
+    @abc.abstractmethod
+    def __init__(self, logger: Optional[Logger] = None):
+        self.logger = logger or get_logger(__name__, type(self))
+
+    @abc.abstractmethod
+    def get_current_thread(self) -> Any:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def do_abort(self, thread: Any) -> None:
+        raise NotImplementedError
+
+    def add_abortable(self, message_id: str) -> None:
+        self.abortable_messages[message_id] = self.get_current_thread()
+
+    def remove_abortable(self, message_id: str) -> None:
+        with self.lock:
+            thread = self.abortable_messages.pop(message_id, None)
+            if thread:
+                saved_message_id, _ = self.abort_requests.pop(thread, (None, None))
+                assert not saved_message_id or message_id == saved_message_id
+
+    def get_abortables(self) -> List[str]:
+        return list(self.abortable_messages.keys())
+
+    def get_abort_request(self, message_id: Optional[str] = None) -> Optional[float]:
+        if message_id:
+            thread = self.abortable_messages.get(message_id, None)
+        else:
+            thread = self.get_current_thread()
+        _, abort_time = self.abort_requests.get(thread, (None, None))
+        return abort_time
+
+    def add_abort_request(self, message_id: str, abort_timeout: int = 0) -> None:
+        with self.lock:
+            thread = self.abortable_messages.get(message_id, None)
+            if thread is None:
+                # If the task finished before we signaled it to abort
+                return
+            self.abort_requests[thread] = (
+                message_id,
+                time.monotonic() + abort_timeout / 1000,
+            )
+
+    def abort_pending(self) -> None:
+        with self.lock:
+            toabort = [
+                thread
+                for thread, (_, abort_time) in self.abort_requests.items()
+                if time.monotonic() >= abort_time
+            ]
+
+            for thread in toabort:
+                message_id, abort_time = self.abort_requests.pop(thread, ("", None))
+                saved_thread = self.abortable_messages.pop(message_id, None)
+                assert saved_thread == thread
+
+                self.logger.info(
+                    "Aborting task. Raising exception in worker thread %r.", thread
+                )
+                self.do_abort(thread)
+
+
+class CtypesAbortManager(AbortManager):
+    """Manager for raising Abort exceptions via the ctypes api."""
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        # This lock is used to avoid a race between the monitor and a task cleaning up.
+        self.lock = threading.Lock()
+        self.abortable_messages: Dict[str, Thread] = {}
+        self.abort_requests: Dict[Thread, Tuple[str, float]] = {}
+
+    def get_current_thread(self) -> Thread:
+        return threading.current_thread()
+
+    def do_abort(self, thread: Thread) -> None:
+        raise_thread_exception(thread.ident, Abort)
+
+
+if is_gevent_active():
+    from gevent import Greenlet, getcurrent
+
+    class GeventAbortManager(AbortManager):
+        """Manager for raising Abort exceptions in green threads."""
+
+        def __init__(self, *args: Any, **kwargs: Any):
+            super().__init__(*args, **kwargs)
+            # No lock is needed for gevent
+            self.lock = contextlib.nullcontext()
+            self.abortable_messages: Dict[str, Greenlet] = {}
+            self.abort_requests: Dict[Greenlet, Tuple[str, float]] = {}
+
+        def get_current_thread(self) -> Greenlet:
+            return getcurrent()
+
+        def do_abort(self, thread: Greenlet) -> None:
+            thread.kill(Abort, block=False)

--- a/src/dramatiq_abort/abort_manager.py
+++ b/src/dramatiq_abort/abort_manager.py
@@ -38,9 +38,10 @@ class AbortManager(abc.ABC):
     """
 
     logger: Any
+    # This lock is used to avoid tasks finishing while they are being aborted
     lock: ContextManager[Any]
-    abortable_messages: Dict[str, Any]
-    abort_requests: Dict[Any, Tuple[str, float]]
+    abortable_messages: Dict[str, Any]  # message_id -> thread
+    abort_requests: Dict[Any, Tuple[str, float]]  # thread -> (message_id, abort_time)
 
     @abc.abstractmethod
     def __init__(self, logger: Optional[Logger] = None):
@@ -110,7 +111,6 @@ class CtypesAbortManager(AbortManager):
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
-        # This lock is used to avoid a race between the monitor and a task cleaning up.
         self.lock = threading.Lock()
         self.abortable_messages: Dict[str, Thread] = {}
         self.abort_requests: Dict[Thread, Tuple[str, float]] = {}

--- a/src/dramatiq_abort/abort_manager.py
+++ b/src/dramatiq_abort/abort_manager.py
@@ -48,11 +48,11 @@ class AbortManager(abc.ABC):
         self.logger = logger or get_logger(__name__, type(self))
 
     @abc.abstractmethod
-    def get_current_thread(self) -> Any:
+    def get_current_thread(self) -> Any:  # pragma: no cover
         raise NotImplementedError
 
     @abc.abstractmethod
-    def do_abort(self, thread: Any) -> None:
+    def do_abort(self, thread: Any) -> None:  # pragma: no cover
         raise NotImplementedError
 
     def add_abortable(self, message_id: str) -> None:

--- a/src/dramatiq_abort/backend.py
+++ b/src/dramatiq_abort/backend.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Dict, Iterable, Optional, Tuple, NamedTuple
+from typing import Any, Dict, Iterable, NamedTuple, Optional
 
 
 class Event(NamedTuple):
@@ -41,9 +41,7 @@ class EventBackend(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def notify(
-        self, events: Iterable[Event], ttl: int
-    ) -> None:  # pragma: no cover
+    def notify(self, events: Iterable[Event], ttl: int) -> None:  # pragma: no cover
         """Signal events.
 
         Once notified, a call to :any:`poll` or :any:`wait_many` with this event should

--- a/src/dramatiq_abort/backend.py
+++ b/src/dramatiq_abort/backend.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Iterable, List, Optional
+from typing import Any, Dict, Iterable, Optional, Tuple
 
 
 class EventBackend(abc.ABC):
@@ -7,8 +7,8 @@ class EventBackend(abc.ABC):
 
     @abc.abstractmethod
     def wait_many(
-        self, keys: List[bytes], timeout: int
-    ) -> Optional[bytes]:  # pragma: no cover
+        self, keys: Iterable[str], timeout: int
+    ) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:  # pragma: no cover
         """Wait for either one of the event in ``keys`` to be signaled or
         ``timeout`` milliseconds to elapsed.
 
@@ -23,7 +23,7 @@ class EventBackend(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def poll(self, key: bytes) -> bool:  # pragma: no cover
+    def poll(self, key: str) -> Optional[Dict[str, Any]]:  # pragma: no cover
         """Check if an event has been signaled.
 
         This function should not block and wait for an event to signal.
@@ -36,7 +36,9 @@ class EventBackend(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def notify(self, keys: Iterable[bytes], ttl: int) -> None:  # pragma: no cover
+    def notify(
+        self, items: Iterable[Tuple[str, Dict[str, Any]]], ttl: int
+    ) -> None:  # pragma: no cover
         """Signal events.
 
         Once notified, a call to :any:`poll` or :any:`wait_many` with this event should

--- a/src/dramatiq_abort/backend.py
+++ b/src/dramatiq_abort/backend.py
@@ -1,5 +1,10 @@
 import abc
-from typing import Any, Dict, Iterable, Optional, Tuple
+from typing import Any, Dict, Iterable, Optional, Tuple, NamedTuple
+
+
+class Event(NamedTuple):
+    key: str
+    params: Dict[str, Any]
 
 
 class EventBackend(abc.ABC):
@@ -8,7 +13,7 @@ class EventBackend(abc.ABC):
     @abc.abstractmethod
     def wait_many(
         self, keys: Iterable[str], timeout: int
-    ) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:  # pragma: no cover
+    ) -> Optional[Event]:  # pragma: no cover
         """Wait for either one of the event in ``keys`` to be signaled or
         ``timeout`` milliseconds to elapsed.
 
@@ -23,7 +28,7 @@ class EventBackend(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def poll(self, key: str) -> Optional[Dict[str, Any]]:  # pragma: no cover
+    def poll(self, key: str) -> Optional[Event]:  # pragma: no cover
         """Check if an event has been signaled.
 
         This function should not block and wait for an event to signal.
@@ -37,7 +42,7 @@ class EventBackend(abc.ABC):
 
     @abc.abstractmethod
     def notify(
-        self, items: Iterable[Tuple[str, Dict[str, Any]]], ttl: int
+        self, events: Iterable[Event], ttl: int
     ) -> None:  # pragma: no cover
         """Signal events.
 

--- a/src/dramatiq_abort/backend.py
+++ b/src/dramatiq_abort/backend.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, Iterable, NamedTuple, Optional
 
 
 class Event(NamedTuple):
+    """Events are composed of an identifying key and associated parameters."""
+
     key: str
     params: Dict[str, Any]
 
@@ -14,7 +16,7 @@ class EventBackend(abc.ABC):
     def wait_many(
         self, keys: Iterable[str], timeout: int
     ) -> Optional[Event]:  # pragma: no cover
-        """Wait for either one of the event in ``keys`` to be signaled or
+        """Wait for either one of the events in ``keys`` to be signaled or
         ``timeout`` milliseconds to elapsed.
 
         Returns the event that signaled or ``None`` if no event was signaled.
@@ -32,9 +34,9 @@ class EventBackend(abc.ABC):
         """Check if an event has been signaled.
 
         This function should not block and wait for an event to signal.
-        Returns ``True`` if the event was signaled, ``False`` otherwise.
+        Returns the event if it was signaled, ``None`` otherwise.
         A backend might not be idempotent and once a key has signaled,
-        subsequent call returns ``False``.
+        subsequent calls might return ``None``.
 
         :param key: Event to check for signal.
         """

--- a/src/dramatiq_abort/backends/redis.py
+++ b/src/dramatiq_abort/backends/redis.py
@@ -1,10 +1,9 @@
 import json
-from typing import Any, Dict, Iterable, Optional, Tuple, Union, overload
+from typing import Any, Dict, Iterable, Optional, Tuple
 
 import redis
 
-from ..backend import EventBackend, Event
-
+from ..backend import Event, EventBackend
 
 DEFAULT_NAMESPACE = "dramatiq:aborts:"
 
@@ -36,9 +35,7 @@ class RedisBackend(EventBackend):
             **kwargs,
         )
 
-    def wait_many(
-        self, keys: Iterable[str], timeout: int
-    ) -> Optional[Event]:
+    def wait_many(self, keys: Iterable[str], timeout: int) -> Optional[Event]:
         assert timeout is None or timeout >= 1000, "wait timeouts must be >= 1000"
         event: Optional[Tuple[bytes, Optional[bytes]]]
         event = self.client.blpop(

--- a/src/dramatiq_abort/backends/redis.py
+++ b/src/dramatiq_abort/backends/redis.py
@@ -46,7 +46,7 @@ class RedisBackend(EventBackend):
         if not event:
             return None
         key, value = self._decode_key(event[0]), self._decode_value(event[1])
-        if not key or value is None:
+        if value is None:
             return None
         return Event(key, value)
 
@@ -69,11 +69,11 @@ class RedisBackend(EventBackend):
 
     @staticmethod
     def _encode_value(value: Dict[str, Any]) -> bytes:
+        if not isinstance(value, dict):  # pragma: no cover
+            raise TypeError("Must provide a dict in params")
         return json.dumps(value).encode()
 
-    def _decode_key(self, key: Optional[bytes]) -> Optional[str]:
-        if not key:
-            return None
+    def _decode_key(self, key: bytes) -> str:
         return key.decode()[len(self.namespace) :]
 
     @staticmethod

--- a/src/dramatiq_abort/backends/redis.py
+++ b/src/dramatiq_abort/backends/redis.py
@@ -3,10 +3,10 @@ from typing import Any, Dict, Iterable, Optional, Tuple, Union, overload
 
 import redis
 
-from ..backend import EventBackend
+from ..backend import EventBackend, Event
 
-MARKER = "dramatiq-abort_marker"
-DEFAULT_NAMESPACE = "dramatiq:abort:"
+
+DEFAULT_NAMESPACE = "dramatiq:aborts:"
 
 
 class RedisBackend(EventBackend):
@@ -18,9 +18,9 @@ class RedisBackend(EventBackend):
     .. _`redis client`: https://pypi.org/project/redis/
     """
 
-    def __init__(self, *, client: Any, namespace: Optional[str] = None) -> None:
+    def __init__(self, *, client: Any, namespace: str = DEFAULT_NAMESPACE) -> None:
         self.client = client
-        self.namespace = namespace or DEFAULT_NAMESPACE
+        self.namespace = namespace
 
     @classmethod
     def from_url(cls, url: str, *args: Any, **kwargs: Any) -> "RedisBackend":
@@ -38,77 +38,53 @@ class RedisBackend(EventBackend):
 
     def wait_many(
         self, keys: Iterable[str], timeout: int
-    ) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+    ) -> Optional[Event]:
         assert timeout is None or timeout >= 1000, "wait timeouts must be >= 1000"
         event: Optional[Tuple[bytes, Optional[bytes]]]
         event = self.client.blpop(
-            [self._encode(key=key) for key in keys], (timeout or 0) // 1000
+            [self._encode_key(key) for key in keys], (timeout or 0) // 1000
         )
         if not event:
-            return None, None
-        return self._decode(key=event[0], value=event[1])
+            return None
+        key, value = self._decode_key(event[0]), self._decode_value(event[1])
+        if not key or not value:
+            return None
+        return Event(key, value)
 
-    def poll(self, key: str) -> Optional[Dict[str, Any]]:
-        event: Optional[bytes] = self.client.lpop(self._encode(key=key))
-        return self._decode(value=event)
+    def poll(self, key: str) -> Optional[Event]:
+        encoded_value: Optional[bytes] = self.client.lpop(self._encode_key(key))
+        value = self._decode_value(encoded_value)
+        if not value:
+            return None
+        return Event(key, value)
 
-    def notify(self, items: Iterable[Tuple[str, Dict[str, Any]]], ttl: int) -> None:
+    def notify(self, events: Iterable[Event], ttl: int) -> None:
         with self.client.pipeline() as pipe:
-            for key, val in items:
-                pipe.rpush(*self._encode(key=key, value=val))
-                pipe.pexpire(key, ttl)
+            for key, val in events:
+                pipe.rpush(self._encode_key(key), self._encode_value(val))
+                pipe.pexpire(self._encode_key(key), ttl)
             pipe.execute()
 
-    def _encode(
-        self, *, key: Optional[str], value: Optional[Dict[str, Any]] = None
-    ) -> Union[None, bytes, Tuple[bytes, bytes]]:
-        encoded_key = (self.namespace + key).encode() if key else None
-        encoded_value = (
-            json.dumps((MARKER, value)).encode() if value is not None else None
-        )
-
-        if encoded_key and encoded_value:
-            return encoded_key, encoded_value
-        elif encoded_value:
-            return encoded_value
-        return encoded_key
-
-    @overload
-    def _decode(self, *, key: Optional[bytes]) -> Optional[str]:
-        ...
-
-    @overload
-    def _decode(self, *, value: Optional[bytes]) -> Optional[Dict[str, Any]]:
-        ...
-
-    @overload
-    def _decode(
-        self, *, key: bytes, value: Optional[bytes]
-    ) -> Tuple[str, Optional[Dict[str, Any]]]:
-        ...
-
-    def _decode(
-        self, *, key: Optional[bytes] = None, value: Optional[bytes] = None
-    ) -> Union[None, str, Dict[str, Any], Tuple[str, Optional[Dict[str, Any]]]]:
-        decoded_key = key.decode()[len(self.namespace) :] if key else None
-        decoded_value = self._decode_value(value) if value else None
-        if decoded_key and decoded_value:
-            return decoded_key, decoded_value
-        elif decoded_value:
-            return decoded_value
-        return decoded_key
+    def _encode_key(self, key: str) -> bytes:
+        return (self.namespace + key).encode()
 
     @staticmethod
-    def _decode_value(val: bytes) -> Optional[Dict[str, Any]]:
+    def _encode_value(value: Optional[Dict[str, Any]]) -> bytes:
+        return json.dumps(value).encode()
+
+    def _decode_key(self, key: Optional[bytes]) -> Optional[str]:
+        if not key:
+            return None
+        return key.decode()[len(self.namespace) :]
+
+    @staticmethod
+    def _decode_value(value: Optional[bytes]) -> Optional[Dict[str, Any]]:
+        if not value:
+            return None
         try:
-            val = json.loads(val)
-            if (
-                not isinstance(val, list)
-                or len(val) != 2
-                or val[0] != MARKER
-                or not isinstance(val[1], dict)
-            ):
+            value = json.loads(value)
+            if not isinstance(value, dict):
                 return None
-            return val[1]
+            return value
         except (UnicodeError, json.JSONDecodeError):
             return None

--- a/src/dramatiq_abort/backends/redis.py
+++ b/src/dramatiq_abort/backends/redis.py
@@ -12,6 +12,7 @@ class RedisBackend(EventBackend):
     """An event backend for Redis_.
 
     :param client: The `Redis client`_ instance.
+    :param namespace: Namespace to prefix keys with.
 
     .. _redis: https://redis.io
     .. _`redis client`: https://pypi.org/project/redis/
@@ -24,6 +25,7 @@ class RedisBackend(EventBackend):
     @classmethod
     def from_url(cls, url: str, *args: Any, **kwargs: Any) -> "RedisBackend":
         """Initialize the backend using an URL to the Redis server.
+        Any extra parameters are passed on to the default constructor.
 
         :param url: Redis server URL.
         """

--- a/src/dramatiq_abort/backends/redis.py
+++ b/src/dramatiq_abort/backends/redis.py
@@ -51,7 +51,7 @@ class RedisBackend(EventBackend):
     def poll(self, key: str) -> Optional[Event]:
         encoded_value: Optional[bytes] = self.client.lpop(self._encode_key(key))
         value = self._decode_value(encoded_value)
-        if not value:
+        if value is None:
             return None
         return Event(key, value)
 

--- a/src/dramatiq_abort/backends/redis.py
+++ b/src/dramatiq_abort/backends/redis.py
@@ -1,8 +1,12 @@
-from typing import Any, Iterable, List, Optional, Tuple
+import json
+from typing import Any, Dict, Iterable, Optional, Tuple, Union, overload
 
 import redis
 
 from ..backend import EventBackend
+
+MARKER = "dramatiq-abort_marker"
+DEFAULT_NAMESPACE = "dramatiq:abort:"
 
 
 class RedisBackend(EventBackend):
@@ -14,38 +18,97 @@ class RedisBackend(EventBackend):
     .. _`redis client`: https://pypi.org/project/redis/
     """
 
-    def __init__(self, *, client: Any) -> None:
+    def __init__(self, *, client: Any, namespace: Optional[str] = None) -> None:
         self.client = client
+        self.namespace = namespace or DEFAULT_NAMESPACE
 
     @classmethod
-    def from_url(cls, url: str) -> "RedisBackend":
+    def from_url(cls, url: str, *args: Any, **kwargs: Any) -> "RedisBackend":
         """Initialize the backend using an URL to the Redis server.
 
         :param url: Redis server URL.
         """
         return cls(
-            client=redis.StrictRedis(connection_pool=redis.ConnectionPool.from_url(url))
+            *args,
+            client=redis.StrictRedis(
+                connection_pool=redis.ConnectionPool.from_url(url)
+            ),
+            **kwargs,
         )
 
-    def wait_many(self, keys: List[bytes], timeout: int) -> Optional[bytes]:
+    def wait_many(
+        self, keys: Iterable[str], timeout: int
+    ) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
         assert timeout is None or timeout >= 1000, "wait timeouts must be >= 1000"
-        event: Optional[Tuple[bytes, bytes]] = self.client.blpop(
-            keys, (timeout or 0) // 1000
+        event: Optional[Tuple[bytes, Optional[bytes]]]
+        event = self.client.blpop(
+            [self._encode(key=key) for key in keys], (timeout or 0) // 1000
         )
-        if event is None:
-            return None
-        key, value = event
-        if value != b"x":
-            return None
-        return key
+        if not event:
+            return None, None
+        return self._decode(key=event[0], value=event[1])
 
-    def poll(self, key: bytes) -> bool:
-        event: Optional[bytes] = self.client.lpop(key)
-        return event == b"x"
+    def poll(self, key: str) -> Optional[Dict[str, Any]]:
+        event: Optional[bytes] = self.client.lpop(self._encode(key=key))
+        return self._decode(value=event)
 
-    def notify(self, keys: Iterable[bytes], ttl: int) -> None:
+    def notify(self, items: Iterable[Tuple[str, Dict[str, Any]]], ttl: int) -> None:
         with self.client.pipeline() as pipe:
-            for key in keys:
-                pipe.rpush(key, b"x")
+            for key, val in items:
+                pipe.rpush(*self._encode(key=key, value=val))
                 pipe.pexpire(key, ttl)
             pipe.execute()
+
+    def _encode(
+        self, *, key: Optional[str], value: Optional[Dict[str, Any]] = None
+    ) -> Union[None, bytes, Tuple[bytes, bytes]]:
+        encoded_key = (self.namespace + key).encode() if key else None
+        encoded_value = (
+            json.dumps((MARKER, value)).encode() if value is not None else None
+        )
+
+        if encoded_key and encoded_value:
+            return encoded_key, encoded_value
+        elif encoded_value:
+            return encoded_value
+        return encoded_key
+
+    @overload
+    def _decode(self, *, key: Optional[bytes]) -> Optional[str]:
+        ...
+
+    @overload
+    def _decode(self, *, value: Optional[bytes]) -> Optional[Dict[str, Any]]:
+        ...
+
+    @overload
+    def _decode(
+        self, *, key: bytes, value: Optional[bytes]
+    ) -> Tuple[str, Optional[Dict[str, Any]]]:
+        ...
+
+    def _decode(
+        self, *, key: Optional[bytes] = None, value: Optional[bytes] = None
+    ) -> Union[None, str, Dict[str, Any], Tuple[str, Optional[Dict[str, Any]]]]:
+        decoded_key = key.decode()[len(self.namespace) :] if key else None
+        decoded_value = self._decode_value(value) if value else None
+        if decoded_key and decoded_value:
+            return decoded_key, decoded_value
+        elif decoded_value:
+            return decoded_value
+        return decoded_key
+
+    @staticmethod
+    def _decode_value(val: bytes) -> Optional[Dict[str, Any]]:
+        try:
+            val = json.loads(val)
+            if (
+                not isinstance(val, list)
+                or len(val) != 2
+                or val[0] != MARKER
+                or not isinstance(val[1], dict)
+            ):
+                return None
+            return val[1]
+        except (UnicodeError, json.JSONDecodeError):
+            return None

--- a/src/dramatiq_abort/backends/redis.py
+++ b/src/dramatiq_abort/backends/redis.py
@@ -46,7 +46,7 @@ class RedisBackend(EventBackend):
         if not event:
             return None
         key, value = self._decode_key(event[0]), self._decode_value(event[1])
-        if not key or not value:
+        if not key or value is None:
             return None
         return Event(key, value)
 
@@ -68,7 +68,7 @@ class RedisBackend(EventBackend):
         return (self.namespace + key).encode()
 
     @staticmethod
-    def _encode_value(value: Optional[Dict[str, Any]]) -> bytes:
+    def _encode_value(value: Dict[str, Any]) -> bytes:
         return json.dumps(value).encode()
 
     def _decode_key(self, key: Optional[bytes]) -> Optional[str]:

--- a/src/dramatiq_abort/backends/stub.py
+++ b/src/dramatiq_abort/backends/stub.py
@@ -1,7 +1,7 @@
 from threading import Condition
-from typing import Any, Dict, Iterable, Optional, Tuple
+from typing import Any, Dict, Iterable, Optional
 
-from ..backend import EventBackend, Event
+from ..backend import Event, EventBackend
 
 
 class StubBackend(EventBackend):
@@ -9,9 +9,7 @@ class StubBackend(EventBackend):
         self.condition = Condition()
         self.events: Dict[str, Dict[str, Any]] = dict()
 
-    def wait_many(
-        self, keys: Iterable[str], timeout: int
-    ) -> Optional[Event]:
+    def wait_many(self, keys: Iterable[str], timeout: int) -> Optional[Event]:
         with self.condition:
             if self.condition.wait_for(
                 lambda: self._anyset(keys), timeout=timeout / 1000

--- a/src/dramatiq_abort/middleware.py
+++ b/src/dramatiq_abort/middleware.py
@@ -201,9 +201,14 @@ def abort(
     :param abort_ttl: Change default abort TTL value, optional argument. If set to
         ``None`` default value from :class:`Abortable` is used.
 
-    :param mode: "AbortMode.ABORT" or "AbortMode.CANCEL".In "cancel" mode,
+    :param mode: "AbortMode.ABORT" or "AbortMode.CANCEL". In "cancel" mode,
         only pending message will be aborted,
         running message will also be aborted additionally in "abort" mode.
+
+    :param abort_timeout: Only applicable when mode is "AbortMode.ABORT".
+        If set, signals the running message that an abort is requested and waits for the
+        given number of milliseconds for it to finish before aborting it.
+        Messages can check if an abort is requested by calling :meth:`abort_requested`.
     """
     if not middleware:
         middleware = _get_abortable_from_broker()
@@ -215,6 +220,15 @@ def abort_requested(
     message_id: Optional[str] = None,
     middleware: Optional[Abortable] = None,
 ) -> Optional[float]:
+    """Check if there is an abort request for the current message. Returns the number of
+    milliseconds until the message is aborted via an exception or ``None`` if no abort
+    is requested.
+
+    :param message_id: If provided, checks for a abort request for the given
+        ``message_id`` instead of the current message.
+
+    :param middleware: As in :meth:`abort`.
+    """
     if not middleware:
         middleware = _get_abortable_from_broker()
     return middleware.get_abort_request(message_id)

--- a/tests/backends/test_redis.py
+++ b/tests/backends/test_redis.py
@@ -1,7 +1,10 @@
+from dramatiq_abort import Event
 from dramatiq_abort.backends import RedisBackend
 
 
-def test_redis_backend_wait_many_error(redis_event_backend: RedisBackend) -> None:
-    # A key without the sentinel value returns None.
-    redis_event_backend.client.rpush(b"test", b"not-x")
-    assert redis_event_backend.wait_many([b"test"], timeout=1000) is None
+def test_redis_namespace(redis_event_backend: RedisBackend) -> None:
+    event = Event(key="test_key", params=dict())
+    redis_event_backend.namespace = "test_namespace:"
+    redis_event_backend.notify([event], 1000)
+    assert redis_event_backend.client.lindex("test_namespace:test_key", 0) == b"{}"
+    assert redis_event_backend.wait_many([event.key], timeout=1000) == event

--- a/tests/backends/test_redis.py
+++ b/tests/backends/test_redis.py
@@ -3,8 +3,19 @@ from dramatiq_abort.backends import RedisBackend
 
 
 def test_redis_namespace(redis_event_backend: RedisBackend) -> None:
-    event = Event(key="test_key", params=dict())
     redis_event_backend.namespace = "test_namespace:"
+    event = Event(key="test_key", params=dict())
     redis_event_backend.notify([event], 1000)
     assert redis_event_backend.client.lindex("test_namespace:test_key", 0) == b"{}"
     assert redis_event_backend.wait_many([event.key], timeout=1000) == event
+
+
+def test_redis_decoding(redis_event_backend: RedisBackend) -> None:
+    redis_event_backend.namespace = "test_namespace:"
+    valid_event = Event(key="test_key3", params=dict(valid=1))
+    redis_event_backend.client.rpush("test_namespace:test_key1", b"not-a-json")
+    redis_event_backend.client.rpush("test_namespace:test_key2", b'["not-a-dict"]')
+    redis_event_backend.client.rpush("test_namespace:test_key3", b'{"valid": 1}')
+    assert redis_event_backend.wait_many(["test_key1"], timeout=1000) is None
+    assert redis_event_backend.poll("test_key2") is None
+    assert redis_event_backend.poll("test_key3") == valid_event

--- a/tests/test_abortable.py
+++ b/tests/test_abortable.py
@@ -10,6 +10,7 @@ from _pytest.logging import LogCaptureFixture
 from dramatiq.middleware import threading
 
 from dramatiq_abort import Abort, Abortable, EventBackend, abort, abort_requested
+from dramatiq_abort.abort_manager import AbortRequest
 from dramatiq_abort.middleware import AbortMode, is_gevent_active
 
 not_supported = threading.current_platform not in threading.supported_platforms
@@ -337,13 +338,13 @@ def test_worker_abort_messages(
     }
 
     # Add an overdue abort request and a delayed one
-    middleware.manager.abort_requests[thread1] = (
-        "fake_message_id_overdue",
-        time.monotonic() - 10,
+    middleware.manager.abort_requests[thread1] = AbortRequest(
+        message_id="fake_message_id_overdue",
+        abort_time=time.monotonic() - 10,
     )
-    middleware.manager.abort_requests[thread2] = (
-        "fake_message_id_delayed",
-        time.monotonic() + 10,
+    middleware.manager.abort_requests[thread2] = AbortRequest(
+        message_id="fake_message_id_delayed",
+        abort_time=time.monotonic() + 10,
     )
     middleware.manager.abort_pending()
 
@@ -384,13 +385,13 @@ def test_gevent_worker_abort_messages(
     }
 
     # Add an overdue abort request and a delayed one
-    middleware.manager.abort_requests[greenlet1] = (
-        "fake_message_id_overdue",
-        time.monotonic() - 10,
+    middleware.manager.abort_requests[greenlet1] = AbortRequest(
+        message_id="fake_message_id_overdue",
+        abort_time=time.monotonic() - 10,
     )
-    middleware.manager.abort_requests[greenlet2] = (
-        "fake_message_id_delayed",
-        time.monotonic() + 10,
+    middleware.manager.abort_requests[greenlet2] = AbortRequest(
+        message_id="fake_message_id_delayed",
+        abort_time=time.monotonic() + 10,
     )
     middleware.manager.abort_pending()
 


### PR DESCRIPTION
### Backend
- Keys are now strings
- Keys are stored with a dict containing parameters to the abort request
- Redis takes an optional namespace to store keys on

### Middleware
- Abort includes an abort_timeout parameter
- Tasks can check if an abort is requested via `abort_requested`. Returns the number of seconds the task has before an `Abort` exception is raised or `None` if no abort is requested
- "Main loop" split into fetching abort messages and aborting pending tasks

### TODO
- Gevent abort manager
- Tests
- Update documentation