### PR TITLE
chore(deps): update `redis`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ dependencies = [
 
 extra_dependencies = {
     "gevent": ["gevent>=1.1"],
-    "redis": ["redis>=2.0,<4.0"],
+    "redis": ["redis>=2.0,<5.0"],
 }
 
 extra_dependencies["all"] = list(set(sum(extra_dependencies.values(), [])))


### PR DESCRIPTION
# Description

A [security issue](https://github.com/redis/redis-py/issues/2665) affected `redis-py` package. As users, we would like to be able to use `dramatiq-abort` with more recent version of `redis-py` (`>=4.3.6`).

Fixes #19 

# Checklist

- [x] I have performed tests using the `tox` command.