### PR TITLE
sleep wait timeout in watcher on unhandled error

### DIFF
--- a/src/dramatiq_abort/middleware.py
+++ b/src/dramatiq_abort/middleware.py
@@ -158,8 +158,9 @@ class Abortable(Middleware):
                 self.manager.abort_pending()
             except Exception:  # pragma: no cover
                 self.logger.exception(
-                    "Unhandled error while running the time limit handler."
+                    "Unhandled error while running the abort watcher."
                 )
+                time.sleep(self.wait_timeout / 1000)
 
     @staticmethod
     def id_to_key(message_id: str, mode: AbortMode = AbortMode.ABORT) -> str:


### PR DESCRIPTION
Since the watcher runs in an infinite loop, a sleep time should be applied on unhandled exception like for example on Redis connection error (e.g. while calling blpop() in redis backend wait_many()).   
Furthermore, the exception error should reflect the abortable middleware instead of the time limit middleware (replaced "time limit handler" exception string with "abort watcher").