### PR TITLE
allow redis v5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ dependencies = [
 
 extra_dependencies = {
     "gevent": ["gevent>=1.1"],
-    "redis": ["redis>=2.0,<5.0"],
+    "redis": ["redis>=2.0,<6.0"],
 }
 
 extra_dependencies["all"] = list(set(sum(extra_dependencies.values(), [])))


### PR DESCRIPTION
Hi all, I'd like to see if we can support `redis` v5 in the official repo.

[`redis`](https://github.com/redis/redis-py) is now on `v5.0.9` and [`dramatiq`](https://github.com/Bogdanp/dramatiq/blob/master/setup.py) supports `redis` versions <6.0 .

`pytest` passes, and `tox` seems to produce no new errors. I have also tested this in my own application which uses `redis==5.0.3` and the functionality works as intended.