### PR TITLE
Dramatiq abort v1.2.1

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7]
+        python-version: [3.12]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7]
+        python-version: [3.12]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     services:
       redis:
         image: redis:latest

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     services:
       redis:
         image: redis:latest

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,6 @@ include *.md
 
 # Include the license file
 include LICENSE
+
+# Include file to indicate that the package is typed
+include py.typed

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ use_parentheses=True
 line_length=88
 
 [mypy]
-python_version=3.7
+python_version=3.8
 platform=linux
 
 # flake8-mypy expects the two following for sensible formatting

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ use_parentheses=True
 line_length=88
 
 [mypy]
-python_version=3.8
+python_version=3.12
 platform=linux
 
 # flake8-mypy expects the two following for sensible formatting
@@ -44,6 +44,7 @@ ignore_missing_imports=True
 
 # be strict
 disallow_untyped_calls=True
+untyped_calls_exclude = dramatiq
 warn_return_any=True
 strict_optional=True
 warn_no_return=True

--- a/setup.py
+++ b/setup.py
@@ -88,9 +88,12 @@ setup(
     extras_require=extra_dependencies,
     zip_safe=False,
     classifiers=[
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: 3 :: Only",
         "Development Status :: 4 - Beta",
         "Topic :: System :: Distributed Computing",

--- a/src/dramatiq_abort/__init__.py
+++ b/src/dramatiq_abort/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 from .abort_manager import Abort
 from .backend import Event, EventBackend

--- a/src/dramatiq_abort/middleware.py
+++ b/src/dramatiq_abort/middleware.py
@@ -109,7 +109,7 @@ class Abortable(Middleware):
         message: dramatiq.Message,
         *,
         result: Optional[Any] = None,
-        exception: Optional[BaseException] = None
+        exception: Optional[BaseException] = None,
     ) -> None:
         self.manager.remove_abortable(message.message_id)
 

--- a/src/dramatiq_abort/middleware.py
+++ b/src/dramatiq_abort/middleware.py
@@ -72,7 +72,9 @@ class Abortable(Middleware):
     def actor_options(self) -> Set[str]:
         return {"abortable"}
 
-    def is_abortable(self, actor: dramatiq.Actor, message: dramatiq.Message) -> bool:
+    def is_abortable(
+        self, actor: dramatiq.Actor[Any, Any], message: dramatiq.Message[Any]
+    ) -> bool:
         abortable = message.options.get("abortable")
         if abortable is None:
             abortable = actor.options.get("abortable")
@@ -91,7 +93,7 @@ class Abortable(Middleware):
             warnings.warn(msg % current_platform, category=RuntimeWarning, stacklevel=2)
 
     def before_process_message(
-        self, broker: dramatiq.Broker, message: dramatiq.Message
+        self, broker: dramatiq.Broker, message: dramatiq.Message[Any]
     ) -> None:
         actor = broker.get_actor(message.actor_name)
         if not self.is_abortable(actor, message):
@@ -106,7 +108,7 @@ class Abortable(Middleware):
     def after_process_message(
         self,
         broker: dramatiq.Broker,
-        message: dramatiq.Message,
+        message: dramatiq.Message[Any],
         *,
         result: Optional[Any] = None,
         exception: Optional[BaseException] = None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import random
-from typing import Any, Dict
+from typing import Any, Dict, Generator
 
 import dramatiq
 import pytest
@@ -31,7 +31,7 @@ def check_redis(client: Any) -> None:
 
 
 @pytest.fixture()
-def stub_broker() -> dramatiq.Broker:
+def stub_broker() -> Generator[dramatiq.Broker, None, None]:
     broker = StubBroker()
     broker.emit_after("process_boot")
     dramatiq.set_broker(broker)
@@ -41,7 +41,7 @@ def stub_broker() -> dramatiq.Broker:
 
 
 @pytest.fixture()
-def stub_worker(stub_broker: dramatiq.Broker) -> dramatiq.Worker:
+def stub_worker(stub_broker: dramatiq.Broker) -> Generator[dramatiq.Worker, None, None]:
     worker = Worker(stub_broker, worker_timeout=100, worker_threads=32)
     worker.start()
     yield worker

--- a/tests/test_abortable.py
+++ b/tests/test_abortable.py
@@ -1,7 +1,9 @@
 import logging
 import time
+from random import choices
+from string import ascii_lowercase
 from threading import Event
-from typing import Optional
+from typing import Any, Optional
 from unittest import mock
 
 import dramatiq
@@ -253,8 +255,9 @@ def test_abortable_configs(
     is_abortable: bool,
 ) -> None:
     abortable = Abortable(backend=stub_event_backend, abortable=middleware_abortable)
+    actor_name = str.join("", choices(ascii_lowercase, k=6))
 
-    message = dramatiq.Message(
+    message: dramatiq.Message[Any] = dramatiq.Message(
         queue_name="some-queue",
         actor_name="some-actor",
         args=(),
@@ -262,11 +265,11 @@ def test_abortable_configs(
         options={"abortable": message_abortable},
     )
 
-    @dramatiq.actor(abortable=actor_abortable)
-    def actor() -> None:
+    @dramatiq.actor(abortable=actor_abortable, actor_name=actor_name)
+    def foo() -> None:
         pass
 
-    assert abortable.is_abortable(actor, message) == is_abortable
+    assert abortable.is_abortable(foo, message) == is_abortable
 
 
 def test_abort_polling(

--- a/tox.ini
+++ b/tox.ini
@@ -10,10 +10,11 @@ skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    3.7: py37, lint, docs
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
+    3.12: py312, lint, docs
 
 [testenv]
 extras=


### PR DESCRIPTION
## Description

This PR does the following:
1. Removes support for python 3.7
    - removes 3.7 from tox, github actions, project meta data
    - bumps configs that used python 3.7 as their reference (i.e., mypy)
2. Adds support for python 3.11 and 3.12
    - Adds versions to tox, github actions, project meta data
    - updates select type annotations to work with python 3.12 instead of 3.7
3. Adds a random `actor_name` keyword in the `test_abortable_configs` test. 
If tested against `dramatiq==1.17.1`, the current parameterized cases will all fail except for the first one because, the new version of dramatiq with throw the following exception from the [Actor __init__ method](https://github.com/Bogdanp/dramatiq/blob/382534702db167192dfd91d5e751b7f3aafacd3b/dramatiq/actor.py#L68). 
    ```python
    ValueError: An actor named 'actor' is already registered.
    ```
    The previous version [(1.16.0) did not include this check in the __init__ method](https://github.com/Bogdanp/dramatiq/blob/db5cf566fbc1372942b822c690522bd2c75a9358/dramatiq/actor.py#L57).
    To avoid that, generate a random string form `actor_name` to give the test/mock actor function a different name in each test scenario. 
4. Increment dramatiq-abort's patch version to 1.2.1
5. Adds a `py.typed` file and includes it in the build artifact [to indicate the downstream users that this package is typed](https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages)