### PR TITLE
Allow redis 6.x versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ dependencies = [
 
 extra_dependencies = {
     "gevent": ["gevent>=1.1"],
-    "redis": ["redis>=2.0,<6.0"],
+    "redis": ["redis>=2.0,<7.0"],
 }
 
 extra_dependencies["all"] = list(set(sum(extra_dependencies.values(), [])))


### PR DESCRIPTION
See: https://github.com/redis/redis-py/releases/tag/v6.0.0

A cursory look at the codebase of dramatiq-abort shows that everything breaking in 6.0 is not something the library relies on, this PR simply updates the allowed set of redis versions to include 6.x versions.